### PR TITLE
Update to syn 2

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -16,6 +16,6 @@ name = "struple_impl"
 proc-macro = true
 
 [dependencies]
-syn = "1"
+syn = "2"
 quote = "1"
 proc-macro2 = "1"


### PR DESCRIPTION
To reduce the number of crates that needs to be compiled in projects that already migrated to syn 2.

There are some breaking changes but we do not appear to be affected:
https://github.com/dtolnay/syn/releases/tag/2.0.0
